### PR TITLE
Add Vercel Analytics integration

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,3 +1,11 @@
+import { Analytics } from "@vercel/analytics/next";
+
+try {
+  Analytics();
+} catch (error) {
+  console.warn("Vercel analytics injection failed", error);
+}
+
 const fetchJSON = async (path) => {
   const response = await fetch(path);
   if (!response.ok) {

--- a/index.html
+++ b/index.html
@@ -145,6 +145,13 @@
   <script>
     window.CRUX_API_KEY = "YOUR_CRUX_API_KEY";
   </script>
+  <script type="importmap">
+    {
+      "imports": {
+        "@vercel/analytics/next": "./vercel-analytics.js"
+      }
+    }
+  </script>
   <script src="app.js" type="module"></script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "website",
+  "version": "1.0.0",
+  "description": "",
+  "main": "app.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "@vercel/analytics": "^1.1.1"
+  }
+}

--- a/vercel-analytics.js
+++ b/vercel-analytics.js
@@ -1,0 +1,47 @@
+const DEFAULT_SCRIPT_URL = '/_vercel/insights/script.js';
+const SCRIPT_ID = 'vercel-analytics-script';
+const INLINE_SNIPPET_ID = 'vercel-analytics-inline';
+
+const ensureInlineSnippet = () => {
+  if (typeof document === 'undefined') return false;
+  if (document.getElementById(INLINE_SNIPPET_ID)) {
+    return false;
+  }
+
+  const inline = document.createElement('script');
+  inline.id = INLINE_SNIPPET_ID;
+  inline.type = 'text/javascript';
+  inline.text =
+    'window.va = window.va || function() { (window.vaq = window.vaq || []).push(arguments); };';
+  document.head.appendChild(inline);
+  return true;
+};
+
+const ensureExternalScript = (scriptUrl = DEFAULT_SCRIPT_URL) => {
+  if (typeof document === 'undefined') return false;
+  const existing = document.getElementById(SCRIPT_ID);
+  if (existing) {
+    if (!existing.hasAttribute('data-script-url')) {
+      existing.setAttribute('data-script-url', existing.src || scriptUrl);
+    }
+    return false;
+  }
+
+  const script = document.createElement('script');
+  script.id = SCRIPT_ID;
+  script.defer = true;
+  script.src = scriptUrl;
+  script.setAttribute('data-script-url', scriptUrl);
+  script.setAttribute('data-analytics', 'vercel-insights');
+  document.head.appendChild(script);
+  return true;
+};
+
+export function Analytics(options = {}) {
+  const { scriptUrl = DEFAULT_SCRIPT_URL } = options ?? {};
+  const insertedExternal = ensureExternalScript(scriptUrl);
+  const insertedInline = ensureInlineSnippet();
+  return insertedExternal || insertedInline;
+}
+
+export default Analytics;


### PR DESCRIPTION
## Summary
- add an import map entry so the app module can load a local Vercel analytics helper
- create a small helper that injects the Vercel analytics scripts when the page loads
- initialize the analytics helper from the main app bundle and document the dependency in package.json

## Testing
- Not run (analytics script injection only)


------
https://chatgpt.com/codex/tasks/task_e_68e37e24421083268e8cc97051f7453a